### PR TITLE
[fix] If there is no optimizable wallet, we still fall into optimize

### DIFF
--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -1183,6 +1183,10 @@ std::error_code WalletService::autoOptimize(std::string& transactionHash) {
     std::vector<std::string> addresses;
     getAddresses(addresses);
 
+    if (addresses.empty()) {
+      return make_error_code(CryptoNote::error::WalletServiceErrorCode::ALREADY_OPTIMIZED);
+    }
+
     // Determine which wallets can be optimized
     std::vector<WalletWithFusionCount> wallets;
 
@@ -1213,7 +1217,7 @@ std::error_code WalletService::autoOptimize(std::string& transactionHash) {
       }
     }
 
-    if (addresses.empty()) {
+    if (wallets.empty()) {
       return make_error_code(CryptoNote::error::WalletServiceErrorCode::ALREADY_OPTIMIZED);
     }
 


### PR DESCRIPTION
This causes a warning because there is no address passed to optimize.